### PR TITLE
Drop tag guessing

### DIFF
--- a/test/test_algorithm.py
+++ b/test/test_algorithm.py
@@ -71,28 +71,6 @@ class AlgorithmTest(TestCase):
             'Le Titre.mp3'
         )
 
-    def test_guess(self):
-        path = os.path.join(
-            AlgorithmTest.test_root,
-            'Missing Artist - No Title'
-        )
-        # Needed in order to test without user input
-        AudioFile.accept_all_guesses = True
-
-        tidysic = Tidysic(input_dir=path, output_dir=path, guess=True)
-        tidysic.ordering = Ordering([
-            OrderingStep(Tag.Artist, FormattedString("{{artist}}")),
-            OrderingStep(Tag.Title, FormattedString("{{title}}"))
-        ])
-
-        tidysic.scan_folder()
-        tidysic.create_structure()
-
-        self.assertEqual(len(tidysic.root_nodes), 1)
-        song = tidysic.root_nodes[0].children[0]
-        self.assertEqual(song.tags[Tag.Artist], 'Missing Artist')
-        self.assertEqual(song.tags[Tag.Title], 'No Title')
-
     def test_illegal_characters(self):
         path = os.path.join(
             AlgorithmTest.test_root,

--- a/test/test_algorithm.py
+++ b/test/test_algorithm.py
@@ -77,7 +77,7 @@ class AlgorithmTest(TestCase):
             'a bunch of illegal characters'
         )
 
-        tidysic = Tidysic(input_dir=path, output_dir=path, guess=True)
+        tidysic = Tidysic(input_dir=path, output_dir=path)
         tidysic.ordering = Ordering([
             OrderingStep(Tag.Artist, FormattedString('{{artist}}')),
             OrderingStep(Tag.Title, FormattedString('{{artist}} - {{title}}'))
@@ -99,7 +99,7 @@ class AlgorithmTest(TestCase):
         )
         tidysic = Tidysic(input_dir=path, output_dir=path)
         tidysic.ordering = Ordering([
-            OrderingStep(Tag.Artist, FormattedString("{{artist}}"))
+            OrderingStep(Tag.Artist, FormattedString('{{artist}}'))
         ])
         tidysic.scan_folder()
         song = tidysic.audio_files[0]
@@ -117,8 +117,8 @@ class AlgorithmTest(TestCase):
         )
         tidysic = Tidysic(input_dir=path, output_dir=path)
         tidysic.ordering = Ordering([
-            OrderingStep(Tag.Album, FormattedString("{{album}}")),
-            OrderingStep(Tag.Title, FormattedString("{{title}}"))
+            OrderingStep(Tag.Album, FormattedString('{{album}}')),
+            OrderingStep(Tag.Title, FormattedString('{{title}}'))
         ])
         tidysic.scan_folder()
         tidysic.create_structure()

--- a/tidysic/audio_file.py
+++ b/tidysic/audio_file.py
@@ -38,7 +38,7 @@ class AudioFile(object):
 
         Args:
             tag (Tag): Tag the user will be asked to provide
-
+        
         Returns:
             Union[str, int]: Value entered by the user
         '''
@@ -65,7 +65,7 @@ class AudioFile(object):
                     except ValueError:
                         pass
 
-            else:
+                else:
                     self.tags[tag] = value
                     done = True
 
@@ -118,8 +118,8 @@ class AudioFile(object):
                     f'[red]{old}[/red]',
                     f'with [green]{new}[/green]'
                 ]
-        if dry_run:
-            logger.dry_run(message)
+                if dry_run:
+                    logger.dry_run(message)
                 elif verbose:
                     logger.info(message)
 
@@ -128,7 +128,7 @@ class AudioFile(object):
         if not dry_run:
             file_tags.save()
 
-    def build_file_name(self, formatted_string: FormattedString):
+    def build_file_name(self, formatted_string: FormattedString) -> str:
         '''
         Builds the file's whole name, using the given format,
         and appends the extension.

--- a/tidysic/formatted_string.py
+++ b/tidysic/formatted_string.py
@@ -36,12 +36,12 @@ class FormattedString:
             FormattedString.assert_well_written(string)
         except AssertionError as e:
             raise ValueError(
-                f"Could not create FormattedString from {string}: {e}"
+                f'Could not create FormattedString from {string}: {e}'
             )
 
         self._str = string
 
-    def build(self, tags: dict[Tag, Any]):
+    def build(self, tags: dict[Tag, Any]) -> str:
         pattern = r'\{(.*?\{(\w+)(:.+?)?\}.*?)\}'
         matches = re.findall(pattern, self._str)
 
@@ -84,19 +84,19 @@ class FormattedString:
             string (str): String whose format to test.
         '''
         bracket_depth = 0
-        current_tag_name = ""
+        current_tag_name = ''
 
         for i, char in enumerate(string):
             if char == '{':
                 bracket_depth += 1
                 assert bracket_depth <= 2, (
-                    f"Too many opening brackets (col {i})"
+                    f'Too many opening brackets (col {i})'
                 )
 
             elif char == '}':
                 bracket_depth -= 1
                 assert bracket_depth >= 0, (
-                    f"Too many closing brackets (col {i})"
+                    f'Too many closing brackets (col {i})'
                 )
 
                 if bracket_depth == 0:
@@ -104,9 +104,9 @@ class FormattedString:
                         tag.name.lower()
                         for tag in Tag
                     }, (
-                        f"Invalid tag name {current_tag_name}"
+                        f'Invalid tag name {current_tag_name}'
                     )
-                    current_tag_name = ""
+                    current_tag_name = ''
             
             elif bracket_depth == 2:
                 current_tag_name += char

--- a/tidysic/main.py
+++ b/tidysic/main.py
@@ -26,10 +26,10 @@ from tidysic.tidysic import Tidysic
     help='Move non-audio files along with their audio neighbor files.'
 )
 @click.option(
-    '-g',
-    '--guess',
+    '-i',
+    '--interactive',
     is_flag=True,
-    help='Guess the audio file title and artist when there is no IDE tags.'
+    help='Will prompt user input for missing tags.'
 )
 @click.option(
     '-d',
@@ -46,7 +46,15 @@ from tidysic.tidysic import Tidysic
     'target',
     type=click.Path(exists=False, file_okay=False),
 )
-def run(verbose, with_album, with_clutter, guess, dry_run, source, target):
+def run(
+    verbose: bool,
+    with_album: bool,
+    with_clutter: bool,
+    interactive: bool,
+    dry_run: bool,
+    source: str,
+    target: str
+):
     '''
     Organize music contents of the SOURCE folder inside the TARGET folder (will
     be created if needed).
@@ -55,7 +63,7 @@ def run(verbose, with_album, with_clutter, guess, dry_run, source, target):
         input_dir=source,
         output_dir=target,
         dry_run=dry_run,
-        guess=guess,
+        interactive=interactive,
         with_clutter=with_clutter
     )
 

--- a/tidysic/main.py
+++ b/tidysic/main.py
@@ -64,13 +64,14 @@ def run(
         output_dir=target,
         dry_run=dry_run,
         interactive=interactive,
-        with_clutter=with_clutter
+        with_clutter=with_clutter,
+        verbose=verbose
     )
 
     if not with_album:
         tidysic.ordering = Ordering([
-            OrderingStep(Tag.Artist, FormattedString("{{artist}}")),
-            OrderingStep(Tag.Title, FormattedString("{{track}. }{{title}}"))
+            OrderingStep(Tag.Artist, FormattedString('{{artist}}')),
+            OrderingStep(Tag.Title, FormattedString('{{track}. }{{title}}'))
         ])
 
     tidysic.organize()

--- a/tidysic/main.py
+++ b/tidysic/main.py
@@ -29,7 +29,7 @@ from tidysic.tidysic import Tidysic
     '-i',
     '--interactive',
     is_flag=True,
-    help='Will prompt user input for missing tags.'
+    help='Prompt user input for missing tags.'
 )
 @click.option(
     '-d',

--- a/tidysic/ordering.py
+++ b/tidysic/ordering.py
@@ -35,5 +35,5 @@ class Ordering:
                 first one.
         '''
         if self.is_terminal():
-            raise Exception("Ordering reached its end")
+            raise Exception('Ordering reached its end')
         return Ordering(self.steps[1:])

--- a/tidysic/os_utils.py
+++ b/tidysic/os_utils.py
@@ -106,7 +106,7 @@ def remove_file(
     '''
     Deletes `file_path`
     '''
-    _message(f"Deleting file {file_path}", dry_run, verbose)
+    _message(f'Deleting file {file_path}', dry_run, verbose)
 
     if not dry_run:
         os.remove(file_path)

--- a/tidysic/tag.py
+++ b/tidysic/tag.py
@@ -18,3 +18,13 @@ class Tag(Enum):
 
     def __str__(self):
         return self.name
+
+    @staticmethod
+    def numeric_tags() -> set['Tag']:
+        """
+        Returns the set of all tags whose values are integer.
+        """
+        return {
+            Tag.Track,
+            Tag.Year
+        }

--- a/tidysic/tag.py
+++ b/tidysic/tag.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Union
 
 
 class Tag(Enum):
@@ -21,10 +22,32 @@ class Tag(Enum):
 
     @staticmethod
     def numeric_tags() -> set['Tag']:
-        """
+        '''
         Returns the set of all tags whose values are integer.
-        """
+        '''
         return {
             Tag.Track,
             Tag.Year
         }
+
+    @staticmethod
+    def validate_input(tag: 'Tag', value: str) -> Union[str, int]:
+        '''
+        Returns the value provided for the given tag with the correct type.
+
+        Raises a ValueError if the given value isn't valid.
+        '''
+        if tag in {Tag.Track, Tag.Year}:
+            # Value is expected to be an int
+            try:
+                return int(value)
+
+            except ValueError:
+                raise ValueError(
+                    f'{tag.name} expects an integer, '
+                    f'{value} was provided.'
+                )
+        
+        else:
+            # Value is expected to be a string
+            return value

--- a/tidysic/tidysic.py
+++ b/tidysic/tidysic.py
@@ -102,7 +102,7 @@ class Tidysic:
         input_dir,
         output_dir,
         dry_run=False,
-        guess=False,
+        interactive=False,
         verbose=False,
         with_clutter=False
     ):
@@ -110,7 +110,7 @@ class Tidysic:
         self.output_dir = output_dir
 
         self.dry_run = dry_run
-        self.guess = guess
+        self.interactive = interactive
         self.verbose = verbose
         self.with_clutter = with_clutter
 
@@ -290,19 +290,19 @@ class Tidysic:
                         for ordering_step in ordering.steps
                     }
                     and
-                    self.guess
+                    self.interactive
                 ):
-                    file.guess_tags(self.dry_run)
-
-                    tag_value = file.tags[order_tag]
-                    if tag_value is None:
+                    tag_value = file.ask_and_set_tag(order_tag)
+                    if tag_value is None and self.verbose:
                         logger.log(f'Discarded file: {file.file}')
+
                 elif self.verbose:
                     logger.warning(
                         f'File {file.file}\n'
-                        f'could not have its {str(order_tag)} \
-                            tag determined.\n'
-                        f'It will move into "Unknown {str(order_tag)}".'
+                        f'could not have its {str(order_tag)} tag '
+                        'determined.\n'
+                        f'It will move into [blue]Unknown {str(order_tag)}'
+                        'directory.'
                     )
 
             if tag_value not in children:

--- a/tidysic/tidysic.py
+++ b/tidysic/tidysic.py
@@ -381,6 +381,8 @@ class Tidysic:
             if isinstance(node, AudioFile):
                 # Leaf of the structure tree
                 assert ordering.is_terminal()
+
+                node.save_tags(verbose=self.verbose, dry_run=self.dry_run)
                 formatted_string = ordering.steps[0].format
                 move_file(
                     node.file,

--- a/tidysic/tidysic.py
+++ b/tidysic/tidysic.py
@@ -84,7 +84,7 @@ class TreeNode(object):
                 if leaf is not None:
                     return leaf
 
-        assert False, "TreeNode has no child"
+        assert False, 'TreeNode has no child'
 
     def build_name(self, formatted_string: FormattedString):
         '''
@@ -115,9 +115,9 @@ class Tidysic:
         self.with_clutter = with_clutter
 
         self.ordering = Ordering([
-            OrderingStep(Tag.Artist, FormattedString("{{artist}}")),
-            OrderingStep(Tag.Album, FormattedString("{({year}) }{{album}}")),
-            OrderingStep(Tag.Title, FormattedString("{{track}. }{{title}}"))
+            OrderingStep(Tag.Artist, FormattedString('{{artist}}')),
+            OrderingStep(Tag.Album, FormattedString('{({year}) }{{album}}')),
+            OrderingStep(Tag.Title, FormattedString('{{track}. }{{title}}'))
         ])
 
         self.audio_files: list[AudioFile] = []
@@ -273,7 +273,7 @@ class Tidysic:
         Returns:
             Sequence[Union[TreeNode, AudioFile]]: Children of depth one.
         '''
-        assert ordering.steps, "No ordering given"
+        assert ordering.steps, 'No ordering given'
         order_tag = ordering.steps[0].tag
 
         if order_tag == Tag.Title:
@@ -431,7 +431,7 @@ class Tidysic:
         Returns true if the given folder was deleted.
         '''
         if self.dry_run:
-            logger.dry_run(f"Cleaning up {dir_src} and its subfolders")
+            logger.dry_run(f'Cleaning up {dir_src} and its subfolders')
 
         else:
             if not os.path.isdir(dir_src):


### PR DESCRIPTION
Removes the clunky tag guessing (close #75) and replace it with a more concise `interactive` mode, in which missing tags are asked whenever they are in the `Ordering`.

Also reworked a bit the `AudioFile`'s `save_tags` method to be more consistent with the other I/O operations. It is now called at the same time as the file is moved to its target directory.