### PR TITLE
Clutter file tagging

### DIFF
--- a/tests/test_audio_file.py
+++ b/tests/test_audio_file.py
@@ -12,4 +12,4 @@ def test_audio_file_extension():
 
 def test_is_audio_file():
     assert AudioFile.is_audio_file(path)
-    assert AudioFile.is_audio_file(Path('tests/music/normal')) == False
+    assert not AudioFile.is_audio_file(Path('tests/music/normal'))

--- a/tests/test_audio_file.py
+++ b/tests/test_audio_file.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from tidysic.parser.audio_file import AudioFile
+from tidysic.file.audio_file import AudioFile
 
 path = Path('tests/music/normal/normal.mp3')
 audio_file = AudioFile(path)

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -34,13 +34,12 @@ def test_clutter():
 
     assert len(tree.children) == 1
     album_node = tree.children.pop()
-    assert len(album_node.clutter_files) == 0
 
-    assert len(album_node.children) == 1
-    album_clutter_node = album_node.children.pop()
-    assert len(album_clutter_node.clutter_files) == 2
+    assert len(album_node.children) == 0
+    assert len(album_node.clutter_files) == 1
+    album_clutter = album_node.clutter_files.pop()
 
-    for album_clutter in album_clutter_node.clutter_files:
-        assert album_clutter.artist == "Artist Name"
-        assert album_clutter.album == "Album Name"
-        assert album_clutter.title is None
+    assert album_clutter.path.is_dir()
+    assert album_clutter.artist == "Artist Name"
+    assert album_clutter.album == "Album Name"
+    assert album_clutter.title is None

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -34,10 +34,13 @@ def test_clutter():
 
     assert len(tree.children) == 1
     album_node = tree.children.pop()
-    assert len(album_node.clutter_files) == 1
-    album_clutter = album_node.clutter_files.pop()
+    assert len(album_node.clutter_files) == 0
 
-    assert album_clutter.path.is_dir()
-    assert album_clutter.artist == "Artist Name"
-    assert album_clutter.album == "Album Name"
-    assert album_clutter.title is None
+    assert len(album_node.children) == 1
+    album_clutter_node = album_node.children.pop()
+    assert len(album_clutter_node.clutter_files) == 2
+
+    for album_clutter in album_clutter_node.clutter_files:
+        assert album_clutter.artist == "Artist Name"
+        assert album_clutter.album == "Album Name"
+        assert album_clutter.title is None

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
-from tidysic.parser.audio_file import AudioFile
+from tidysic.file.audio_file import AudioFile
+from tidysic.file.clutter_file import ClutterFile
 from tidysic.parser.tree import Tree
 
 
@@ -14,9 +15,15 @@ def test_tree():
             assert isinstance(audio_file, AudioFile)
 
         for clutter_file in root.clutter_files:
-            assert isinstance(clutter_file, Path)
+            assert isinstance(clutter_file, ClutterFile)
 
         for child in root.children:
             iter(child)
 
     iter(tree)
+
+
+def test_clutter():
+    tree = Tree(Path('tests/music/clutter test'))
+
+

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -26,4 +26,18 @@ def test_tree():
 def test_clutter():
     tree = Tree(Path('tests/music/clutter test'))
 
+    assert len(tree.clutter_files) == 1
+    artist_clutter = tree.clutter_files.pop() 
 
+    assert artist_clutter.artist == "Artist Name"
+    assert artist_clutter.album == None
+
+    assert len(tree.children) == 1
+    album_node = tree.children.pop()
+    assert len(album_node.clutter_files) == 1
+    album_clutter = album_node.clutter_files.pop()
+
+    assert album_clutter.path.is_dir()
+    assert album_clutter.artist == "Artist Name"
+    assert album_clutter.album == "Album Name"
+    assert album_clutter.title == None

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -27,10 +27,10 @@ def test_clutter():
     tree = Tree(Path('tests/music/clutter test'))
 
     assert len(tree.clutter_files) == 1
-    artist_clutter = tree.clutter_files.pop() 
+    artist_clutter = tree.clutter_files.pop()
 
     assert artist_clutter.artist == "Artist Name"
-    assert artist_clutter.album == None
+    assert artist_clutter.album is None
 
     assert len(tree.children) == 1
     album_node = tree.children.pop()
@@ -40,4 +40,4 @@ def test_clutter():
     assert album_clutter.path.is_dir()
     assert album_clutter.artist == "Artist Name"
     assert album_clutter.album == "Album Name"
-    assert album_clutter.title == None
+    assert album_clutter.title is None

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tidysic.file.audio_file import AudioFile
-from tidysic.file.clutter_file import ClutterFile
+from tidysic.file.tagged_file import TaggedFile
 from tidysic.parser.tree import Tree
 
 
@@ -15,7 +15,7 @@ def test_tree():
             assert isinstance(audio_file, AudioFile)
 
         for clutter_file in root.clutter_files:
-            assert isinstance(clutter_file, ClutterFile)
+            assert isinstance(clutter_file, TaggedFile)
 
         for child in root.children:
             iter(child)

--- a/tidysic/file/audio_file.py
+++ b/tidysic/file/audio_file.py
@@ -3,10 +3,10 @@ from pathlib import Path
 from mutagen.easyid3 import EasyID3
 from mutagen.id3 import ID3NoHeaderError
 
-from tidysic.file.clutter_file import ClutterFile
+from tidysic.file.tagged_file import TaggedFile
 
 
-class AudioFile(ClutterFile):
+class AudioFile(TaggedFile):
     """Parsed audio file with mutagene, for easily accessing its tags."""
 
     extensions = {

--- a/tidysic/file/audio_file.py
+++ b/tidysic/file/audio_file.py
@@ -3,8 +3,10 @@ from pathlib import Path
 from mutagen.easyid3 import EasyID3
 from mutagen.id3 import ID3NoHeaderError
 
+from tidysic.file.tagged_file import Taggable
 
-class AudioFile:
+
+class AudioFile(Taggable):
     """Parsed audio file with mutagene, for easily accessing its tags."""
 
     extensions = {
@@ -14,23 +16,15 @@ class AudioFile:
         '.wav',
     }
 
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path):
         self.path = path
-
-        self.album: str = 'Unknown'
-        self.artist: str = 'Unknown'
-        self.title: str = path.stem
-        self.genre: str = 'Unknown'
-        self.tracknumber: str = 'Unknown'
-        self.date: str = 'Unknown'
         self.extension: str = self.path.suffix
 
         self._parse()
 
     def _parse(self) -> None:
         tags = self._get_mutagen_tags()
-        for k, v in tags.items():
-            setattr(self, k, v[0])
+        self.set_tags(tags)
 
     def _get_mutagen_tags(self) -> dict:
         try:

--- a/tidysic/file/audio_file.py
+++ b/tidysic/file/audio_file.py
@@ -28,7 +28,10 @@ class AudioFile(ClutterFile):
 
     def _get_mutagen_tags(self) -> dict:
         try:
-            return dict(EasyID3(self.path.resolve()))
+            return dict({
+                k: v[0]
+                for k, v in EasyID3(self.path.resolve()).items()
+            })
         except ID3NoHeaderError:
             return dict()
 

--- a/tidysic/file/audio_file.py
+++ b/tidysic/file/audio_file.py
@@ -28,15 +28,16 @@ class AudioFile(ClutterFile):
 
     def _get_mutagen_tags(self) -> dict:
         try:
-            return dict({
+            return {
                 k: v[0]
                 for k, v in EasyID3(self.path.resolve()).items()
-            })
+            }
         except ID3NoHeaderError:
             return dict()
 
     def get_title_with_extension(self) -> str:
-        return self.title + self.extension
+        title = self.title if self.title is not None else "Unknown track"
+        return title + self.extension
 
     @staticmethod
     def is_audio_file(path: Path) -> bool:

--- a/tidysic/file/audio_file.py
+++ b/tidysic/file/audio_file.py
@@ -3,10 +3,10 @@ from pathlib import Path
 from mutagen.easyid3 import EasyID3
 from mutagen.id3 import ID3NoHeaderError
 
-from tidysic.file.tagged_file import Taggable
+from tidysic.file.clutter_file import ClutterFile
 
 
-class AudioFile(Taggable):
+class AudioFile(ClutterFile):
     """Parsed audio file with mutagene, for easily accessing its tags."""
 
     extensions = {
@@ -17,7 +17,7 @@ class AudioFile(Taggable):
     }
 
     def __init__(self, path: Path):
-        self.path = path
+        super().__init__(path)
         self.extension: str = self.path.suffix
 
         self._parse()

--- a/tidysic/file/clutter_file.py
+++ b/tidysic/file/clutter_file.py
@@ -1,6 +1,11 @@
-from tidysic.file.tagged_file import Taggable
+from pathlib import Path
+
+from tidysic.file.taggable import Taggable
 
 class ClutterFile(Taggable):
 
     def __init__(self, path: Path):
-        self.path = path
+        self.path: Path = path
+
+    def __hash__(self):
+        return hash(self.path)

--- a/tidysic/file/clutter_file.py
+++ b/tidysic/file/clutter_file.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from tidysic.file.taggable import Taggable
 
+
 class ClutterFile(Taggable):
 
     def __init__(self, path: Path):

--- a/tidysic/file/clutter_file.py
+++ b/tidysic/file/clutter_file.py
@@ -1,0 +1,6 @@
+from tidysic.file.tagged_file import Taggable
+
+class ClutterFile(Taggable):
+
+    def __init__(self, path: Path):
+        self.path = path

--- a/tidysic/file/taggable.py
+++ b/tidysic/file/taggable.py
@@ -21,6 +21,23 @@ class Taggable:
             setattr(self, k, v)
 
     @staticmethod
+    def intersection(taggable: 'Taggable', other: 'Taggable') -> 'Taggable':
+        """
+        Returns the intersection of two `Taggable`. Each field will take either
+        the common value, or keep its default value ("Unknown").
+        """
+        taggables_intersection = Taggable()
+
+        for field in fields(taggable):
+            attr = getattr(taggable, field.name)
+            other_attr = getattr(other, field.name)
+            if attr == other_attr:
+                value = attr
+                setattr(taggables_intersection, field.name, value)
+
+        return taggables_intersection
+
+    @staticmethod
     def get_tag_names() -> tuple[str, ...]:
         return tuple(
             field.name

--- a/tidysic/file/taggable.py
+++ b/tidysic/file/taggable.py
@@ -1,14 +1,16 @@
 from dataclasses import dataclass, asdict, fields
 
+from typing import Optional
+
 @dataclass
 class Taggable:
 
-    album: str = None
-    artist: str = None
-    title: str = None
-    genre: str = None
-    tracknumber: str = None
-    date: str = None
+    album: Optional[str] = None
+    artist: Optional[str] = None
+    title: Optional[str] = None
+    genre: Optional[str] = None
+    tracknumber: Optional[str] = None
+    date: Optional[str] = None
 
     def copy_tags_from(self, taggable: 'Taggable'):
         self.set_tags(asdict(taggable))
@@ -18,7 +20,7 @@ class Taggable:
             setattr(self, k, v)
 
     @staticmethod
-    def get_tag_names() -> tuple[str]:
+    def get_tag_names() -> tuple[str, ...]:
         return tuple(
             field.name
             for field in fields(Taggable)

--- a/tidysic/file/taggable.py
+++ b/tidysic/file/taggable.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, fields
 
 @dataclass
 class Taggable:
@@ -17,5 +17,9 @@ class Taggable:
         for k, v in tags.items():
             setattr(self, k, v)
 
-    def get_tags(self) -> dict[str, str]:
-        return asdict(self)
+    @staticmethod
+    def get_tag_names() -> tuple[str]:
+        return tuple(
+            field.name
+            for field in fields(Taggable)
+        )

--- a/tidysic/file/taggable.py
+++ b/tidysic/file/taggable.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, asdict, fields
 
 from typing import Optional
 
+
 @dataclass
 class Taggable:
 

--- a/tidysic/file/taggable.py
+++ b/tidysic/file/taggable.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass, asdict
+
+@dataclass
+class Taggable:
+
+    album: str = None
+    artist: str = None
+    title: str = None
+    genre: str = None
+    tracknumber: str = None
+    date: str = None
+
+    def copy_tags_from(self, taggable: 'Taggable'):
+        self.set_tags(asdict(taggable))
+
+    def set_tags(self, tags: dict[str, str]):
+        for k, v in tags.items():
+            setattr(self, k, v)
+
+    def get_tags(self) -> dict[str, str]:
+        return asdict(self)

--- a/tidysic/file/tagged_file.py
+++ b/tidysic/file/tagged_file.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from tidysic.file.taggable import Taggable
 
 
-class ClutterFile(Taggable):
+class TaggedFile(Taggable):
 
     def __init__(self, path: Path):
         self.path: Path = path

--- a/tidysic/organizer.py
+++ b/tidysic/organizer.py
@@ -2,6 +2,7 @@ import shutil
 from pathlib import Path
 
 from tidysic.file.audio_file import AudioFile
+from tidysic.file.tagged_file import TaggedFile
 from tidysic.parser.tree import Tree
 
 
@@ -16,13 +17,18 @@ class Organizer:
             path.mkdir(parents=True, exist_ok=True)
             Organizer._copy_file(parent=path, audio_file=audio_file)
 
+        for clutter_file in tree.clutter_files:
+            path = target / self._build_path(clutter_file)
+            path.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(clutter_file.path, path)
+
         for child in tree.children:
             self.organize(child, target)
 
-    def _build_path(self, audio_file: AudioFile) -> Path:
+    def _build_path(self, tagged_file: TaggedFile) -> Path:
         path = Path()
         for attribute in self._attributes:
-            folder_name = getattr(audio_file, attribute)
+            folder_name = getattr(tagged_file, attribute)
             if folder_name is None:
                 folder_name = f"Unknown {attribute}"
             path = path / folder_name

--- a/tidysic/organizer.py
+++ b/tidysic/organizer.py
@@ -1,7 +1,7 @@
 import shutil
 from pathlib import Path
 
-from tidysic.parser.audio_file import AudioFile
+from tidysic.file.audio_file import AudioFile
 from tidysic.parser.tree import Tree
 
 

--- a/tidysic/organizer.py
+++ b/tidysic/organizer.py
@@ -22,7 +22,10 @@ class Organizer:
     def _build_path(self, audio_file: AudioFile) -> Path:
         path = Path()
         for attribute in self._attributes:
-            path = path / getattr(audio_file, attribute)
+            folder_name = getattr(audio_file, attribute)
+            if folder_name is None:
+                folder_name = f"Unknown {attribute}"
+            path = path / folder_name
         return path
 
     @staticmethod

--- a/tidysic/parser/tree.py
+++ b/tidysic/parser/tree.py
@@ -33,7 +33,7 @@ class Tree:
         for path in self._root.iterdir():
             if path.is_dir():
                 child = Tree(path)
-                if child._contains_tags():
+                if child.common_tags is not None:
                     self.children.add(child)
                 else:
                     self.clutter_files.add(TaggedFile(path))
@@ -42,56 +42,36 @@ class Tree:
             else:
                 self.clutter_files.add(TaggedFile(path))
 
-        if self._contains_tags():
-            self._tag_clutter()
-
-    def _contains_tags(self) -> bool:
-        """
-        Returns True if this node or any of its children has audio files.
-        """
-        return (
-            self.common_tags is not None
-            or
-            len(self.audio_files) > 0
-            or
-            any(
-                child._contains_tags()
-                for child in self.children
-            )
-        )
+        self._tag_clutter()
 
     def _tag_clutter(self):
         """
         Tags non-audio files with the tags common to all audio files in the same
         directory and subdirectories.
         """
-        common_tags = self._find_common_tags()
-        self._apply_tags_to_clutter(common_tags)
+        self._find_common_tags()
+        self._apply_common_tags_to_clutter()
 
-    def _find_common_tags(self) -> Taggable:
+    def _find_common_tags(self):
         """
         Finds the common tags shared by the given tagged objects.
         """
-        assert self._contains_tags()
-
-        if self.common_tags is not None:
-            return self.common_tags
-
         children_tags = [
-            child._find_common_tags()
+            child.common_tags
             for child in self.children
-            if child._contains_tags()
+            if child.common_tags is not None
         ]
-        all_tags = chain(self.audio_files, children_tags)
-        self.common_tags = reduce(Taggable.intersection, all_tags)
+        all_tags = list(chain(self.audio_files, children_tags))
 
-        return self.common_tags
+        if len(all_tags) > 0:
+            self.common_tags = reduce(Taggable.intersection, all_tags)
 
-    def _apply_tags_to_clutter(self, tags: Taggable):
+    def _apply_common_tags_to_clutter(self):
         """
         Tags clutter in this node with the given tags.
 
         Affects its children if they do not contain audio files.
         """
-        for clutter_file in self.clutter_files:
-            clutter_file.copy_tags_from(tags)
+        if self.common_tags is not None:
+            for clutter_file in self.clutter_files:
+                clutter_file.copy_tags_from(self.common_tags)

--- a/tidysic/parser/tree.py
+++ b/tidysic/parser/tree.py
@@ -72,6 +72,8 @@ class Tree:
         """
         Finds the common tags shared by the given tagged objects.
         """
+        assert self._contains_tags()
+
         if self.common_tags is not None:
             return self.common_tags
 

--- a/tidysic/parser/tree.py
+++ b/tidysic/parser/tree.py
@@ -56,7 +56,7 @@ class Tree:
         def all_tagged() -> Iterator[Taggable]:
             for audio_file in self.audio_files:
                 yield audio_file
-            
+
             for child in self.children:
                 yield child._tag_clutter_and_return_common_tags()
 
@@ -68,7 +68,7 @@ class Tree:
         print()
         for clutter_file in self.clutter_files:
             clutter_file.copy_tags_from(common_tags)
-        
+
         return common_tags
 
     @staticmethod
@@ -90,4 +90,3 @@ class Tree:
                 setattr(common_tags, tag_name, tag_value)
 
         return common_tags
-

--- a/tidysic/parser/tree.py
+++ b/tidysic/parser/tree.py
@@ -4,7 +4,7 @@ from itertools import chain
 from functools import reduce
 
 from tidysic.file.audio_file import AudioFile
-from tidysic.file.clutter_file import ClutterFile
+from tidysic.file.tagged_file import TaggedFile
 from tidysic.file.taggable import Taggable
 
 
@@ -18,7 +18,7 @@ class Tree:
 
         self.children: set['Tree'] = set()
         self.audio_files: set[AudioFile] = set()
-        self.clutter_files: set[ClutterFile] = set()
+        self.clutter_files: set[TaggedFile] = set()
 
         self._parse()
 
@@ -34,7 +34,7 @@ class Tree:
             elif AudioFile.is_audio_file(path):
                 self.audio_files.add(AudioFile(path))
             else:
-                self.clutter_files.add(ClutterFile(path))
+                self.clutter_files.add(TaggedFile(path))
 
         self._tag_clutter()
 

--- a/tidysic/parser/tree.py
+++ b/tidysic/parser/tree.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
-from tidysic.parser.audio_file import AudioFile
+from tidysic.file.audio_file import AudioFile
+from tidysic.file.clutter_file import ClutterFile
+from tidysic.file.taggable import Taggable
 
 
 class Tree:
@@ -13,9 +15,10 @@ class Tree:
 
         self.children: set['Tree'] = set()
         self.audio_files: set[AudioFile] = set()
-        self.clutter_files: set[Path] = set()
+        self.clutter_files: set[ClutterFile] = set()
 
         self._parse()
+        self._parse_non_audio()
 
     def _parse(self) -> None:
         """
@@ -29,4 +32,50 @@ class Tree:
             elif AudioFile.is_audio_file(path):
                 self.audio_files.add(AudioFile(path))
             else:
-                self.clutter_files.add(path)
+                self.clutter_files.add(ClutterFile(path))
+
+    def _parse_non_audio(self) -> None:
+        """
+        Tags non-audio files with the tags common to all audio files in the same
+        directory and subdirectories.
+        """
+        _ = self._tag_clutter_and_return_common_tags()
+
+    def _tag_clutter_and_return_common_tags(self) -> Taggable:
+        """
+        Tags non-audio files with the tags common to all audio files in the same
+        directory and subdirectories, and returns the set of tags.
+        """
+        all_tagged = (
+            list(self.audio_files)
+            +
+            [
+                child._tag_clutter_and_return_common_tags()
+                for child in self.children
+            ]
+        )
+        common_tags = self._find_common_tags(all_tagged)
+        for clutter_file in self.clutter_files:
+            clutter_file.copy_tags_from(common_tags)
+        
+        return common_tags
+
+    @staticmethod
+    def _find_common_tags(
+        tagged_list: list[Taggable]
+    ) -> Taggable:
+        """
+        Finds the common tags shared by the given tagged objects.
+        """
+        common_tags = Taggable()
+        if tagged_list:
+            candidate = tagged_list.pop()
+            for key in common_tags.get_tags():
+                tag_value = getattr(candidate, key)
+                if all([
+                    getattr(tagged, key) == tag_value
+                    for tagged in tagged_list
+                ]):
+                    setattr(common_tags, key, tag_value)
+        return common_tags
+

--- a/tidysic/parser/tree.py
+++ b/tidysic/parser/tree.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
-from typing import Iterator, Callable
+from itertools import chain
+from functools import reduce
 
 from tidysic.file.audio_file import AudioFile
 from tidysic.file.clutter_file import ClutterFile
@@ -20,7 +21,6 @@ class Tree:
         self.clutter_files: set[ClutterFile] = set()
 
         self._parse()
-        self._parse_non_audio()
 
     def _parse(self) -> None:
         """
@@ -30,63 +30,57 @@ class Tree:
         """
         for path in self._root.iterdir():
             if path.is_dir():
-                child = Tree(path)
-                if child.audio_files:
-                    self.children.add(child)
-                else:
-                    self.clutter_files.add(ClutterFile(path))
+                self.children.add(Tree(path))
             elif AudioFile.is_audio_file(path):
                 self.audio_files.add(AudioFile(path))
             else:
                 self.clutter_files.add(ClutterFile(path))
 
-    def _parse_non_audio(self) -> None:
+        self._tag_clutter()
+
+    def _contains_tags(self) -> bool:
+        """
+        Returns True if this node or any of its children has audio files.
+        """
+        return (
+            len(self.audio_files) > 0
+            or
+            any([
+                child._contains_tags()
+                for child in self.children
+            ])
+        )
+
+    def _apply_tags_to_clutter(self, tags: Taggable):
+        """
+        Tags clutter in this node with the given tags.
+
+        Affects its children if they do not contain audio files.
+        """
+        for clutter_file in self.clutter_files:
+            clutter_file.copy_tags_from(tags)
+
+        for child in self.children:
+            if not child._contains_tags():
+                child._apply_tags_to_clutter(tags)
+
+    def _tag_clutter(self):
         """
         Tags non-audio files with the tags common to all audio files in the same
         directory and subdirectories.
         """
-        _ = self._tag_clutter_and_return_common_tags()
+        if self._contains_tags():
+            common_tags = self._find_common_tags()
+            self._apply_tags_to_clutter(common_tags)
 
-    def _tag_clutter_and_return_common_tags(self) -> Taggable:
-        """
-        Tags non-audio files with the tags common to all audio files in the same
-        directory and subdirectories, and returns the set of tags.
-        """
-
-        def all_tagged() -> Iterator[Taggable]:
-            for audio_file in self.audio_files:
-                yield audio_file
-
-            for child in self.children:
-                yield child._tag_clutter_and_return_common_tags()
-
-        for t in all_tagged():
-            print(t)
-
-        common_tags = self._find_common_tags(all_tagged)
-        print(common_tags)
-        print()
-        for clutter_file in self.clutter_files:
-            clutter_file.copy_tags_from(common_tags)
-
-        return common_tags
-
-    @staticmethod
-    def _find_common_tags(
-        taggables: Callable[[], Iterator[Taggable]]
-    ) -> Taggable:
+    def _find_common_tags(self) -> Taggable:
         """
         Finds the common tags shared by the given tagged objects.
         """
-        common_tags = Taggable()
-
-        for tag_name in common_tags.get_tag_names():
-            tag_values = set([
-                getattr(tagged, tag_name)
-                for tagged in taggables()
-            ])
-            if len(tag_values) == 1:
-                tag_value = tag_values.pop()
-                setattr(common_tags, tag_name, tag_value)
-
-        return common_tags
+        children_tags = [
+            child._find_common_tags()
+            for child in self.children
+            if child._contains_tags()
+        ]
+        all_tags = chain(self.audio_files, children_tags)
+        return reduce(Taggable.intersection, all_tags)

--- a/tidysic/parser/tree.py
+++ b/tidysic/parser/tree.py
@@ -28,7 +28,11 @@ class Tree:
         """
         for path in self._root.iterdir():
             if path.is_dir():
-                self.children.add(Tree(path))
+                child = Tree(path)
+                if child.audio_files:
+                    self.children.add(child)
+                else:
+                    self.clutter_files.add(ClutterFile(path))
             elif AudioFile.is_audio_file(path):
                 self.audio_files.add(AudioFile(path))
             else:
@@ -70,12 +74,12 @@ class Tree:
         common_tags = Taggable()
         if tagged_list:
             candidate = tagged_list.pop()
-            for key in common_tags.get_tags():
-                tag_value = getattr(candidate, key)
+            for tag_name in common_tags.get_tag_names():
+                tag_value = getattr(candidate, tag_name)
                 if all([
-                    getattr(tagged, key) == tag_value
+                    getattr(tagged, tag_name) == tag_value
                     for tagged in tagged_list
                 ]):
-                    setattr(common_tags, key, tag_value)
+                    setattr(common_tags, tag_name, tag_value)
         return common_tags
 


### PR DESCRIPTION
Attempt at bringing back clutter file tagging in the parsing process.

Not a fan of how `ClutterFile` is kind of an empty class, and could be a parent of the `AudioFile` class. Also, because of recursion, the method `Tree._tag_clutter_and_return_common_tags` does two things, and cannot be split in a nice way.

Tests are also missing.