### PR TITLE
Clutter files alternate attempt

### DIFF
--- a/tests/test_audio_file.py
+++ b/tests/test_audio_file.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from tidysic.parser.audio_file import AudioFile
+from tidysic.file.audio_file import AudioFile
 
 path = Path('tests/music/normal/normal.mp3')
 audio_file = AudioFile(path)

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
-from tidysic.parser.audio_file import AudioFile
+from tidysic.file.audio_file import AudioFile
+from tidysic.file.clutter_file import ClutterFile
 from tidysic.parser.tree import Tree
 
 
@@ -14,9 +15,15 @@ def test_tree():
             assert isinstance(audio_file, AudioFile)
 
         for clutter_file in root.clutter_files:
-            assert isinstance(clutter_file, Path)
+            assert isinstance(clutter_file, ClutterFile)
 
         for child in root.children:
             iter(child)
 
     iter(tree)
+
+
+def test_clutter():
+    tree = Tree(Path('tests/music/clutter test'))
+
+

--- a/tidysic/file/audio_file.py
+++ b/tidysic/file/audio_file.py
@@ -3,8 +3,10 @@ from pathlib import Path
 from mutagen.easyid3 import EasyID3
 from mutagen.id3 import ID3NoHeaderError
 
+from tidysic.file.tagged_file import Taggable
 
-class AudioFile:
+
+class AudioFile(Taggable):
     """Parsed audio file with mutagene, for easily accessing its tags."""
 
     extensions = {
@@ -14,23 +16,15 @@ class AudioFile:
         '.wav',
     }
 
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path):
         self.path = path
-
-        self.album: str = 'Unknown'
-        self.artist: str = 'Unknown'
-        self.title: str = path.stem
-        self.genre: str = 'Unknown'
-        self.tracknumber: str = 'Unknown'
-        self.date: str = 'Unknown'
         self.extension: str = self.path.suffix
 
         self._parse()
 
     def _parse(self) -> None:
         tags = self._get_mutagen_tags()
-        for k, v in tags.items():
-            setattr(self, k, v[0])
+        self.set_tags(tags)
 
     def _get_mutagen_tags(self) -> dict:
         try:

--- a/tidysic/file/audio_file.py
+++ b/tidysic/file/audio_file.py
@@ -3,10 +3,10 @@ from pathlib import Path
 from mutagen.easyid3 import EasyID3
 from mutagen.id3 import ID3NoHeaderError
 
-from tidysic.file.tagged_file import Taggable
+from tidysic.file.clutter_file import ClutterFile
 
 
-class AudioFile(Taggable):
+class AudioFile(ClutterFile):
     """Parsed audio file with mutagene, for easily accessing its tags."""
 
     extensions = {
@@ -17,7 +17,7 @@ class AudioFile(Taggable):
     }
 
     def __init__(self, path: Path):
-        self.path = path
+        super().__init__(path)
         self.extension: str = self.path.suffix
 
         self._parse()

--- a/tidysic/file/clutter_file.py
+++ b/tidysic/file/clutter_file.py
@@ -1,6 +1,11 @@
-from tidysic.file.tagged_file import Taggable
+from pathlib import Path
+
+from tidysic.file.taggable import Taggable
 
 class ClutterFile(Taggable):
 
     def __init__(self, path: Path):
-        self.path = path
+        self.path: Path = path
+
+    def __hash__(self):
+        return hash(self.path)

--- a/tidysic/file/clutter_file.py
+++ b/tidysic/file/clutter_file.py
@@ -1,0 +1,6 @@
+from tidysic.file.tagged_file import Taggable
+
+class ClutterFile(Taggable):
+
+    def __init__(self, path: Path):
+        self.path = path

--- a/tidysic/file/clutter_file.py
+++ b/tidysic/file/clutter_file.py
@@ -1,11 +1,10 @@
 from pathlib import Path
-
 from tidysic.file.taggable import Taggable
 
 class ClutterFile(Taggable):
 
     def __init__(self, path: Path):
-        self.path: Path = path
+        self.path = path
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.path)

--- a/tidysic/file/taggable.py
+++ b/tidysic/file/taggable.py
@@ -1,21 +1,36 @@
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass, fields
+
 
 @dataclass
 class Taggable:
 
-    album: str = None
-    artist: str = None
-    title: str = None
-    genre: str = None
-    tracknumber: str = None
-    date: str = None
+    album: str = 'Unknown'
+    artist: str = 'Unknown'
+    title: str = 'Unknown'
+    genre: str = 'Unknown'
+    tracknumber: str = 'Unknown'
+    date: str = 'Unknown'
 
-    def copy_tags_from(self, taggable: 'Taggable'):
+    @staticmethod
+    def intersection(taggable: 'Taggable', other: 'Taggable') -> 'Taggable':
+        """
+        Return the intersection of two `Taggable`. Each field will take either
+        the common value, or keep its default value ("Unknown").
+        """
+        taggables_intersection = Taggable()
+        
+        for field in fields(taggable):
+            attr = getattr(taggable, field.name)
+            other_attr = getattr(other, field.name)
+            if attr == other_attr:
+                value = attr
+                setattr(taggables_intersection, field.name, value)
+        
+        return taggables_intersection
+
+    def copy_tags_from(self, taggable: 'Taggable') -> None:
         self.set_tags(asdict(taggable))
 
     def set_tags(self, tags: dict[str, str]):
         for k, v in tags.items():
             setattr(self, k, v)
-
-    def get_tags(self) -> dict[str, str]:
-        return asdict(self)

--- a/tidysic/file/taggable.py
+++ b/tidysic/file/taggable.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass, asdict
+
+@dataclass
+class Taggable:
+
+    album: str = None
+    artist: str = None
+    title: str = None
+    genre: str = None
+    tracknumber: str = None
+    date: str = None
+
+    def copy_tags_from(self, taggable: 'Taggable'):
+        self.set_tags(asdict(taggable))
+
+    def set_tags(self, tags: dict[str, str]):
+        for k, v in tags.items():
+            setattr(self, k, v)
+
+    def get_tags(self) -> dict[str, str]:
+        return asdict(self)

--- a/tidysic/organizer.py
+++ b/tidysic/organizer.py
@@ -1,7 +1,7 @@
 import shutil
 from pathlib import Path
 
-from tidysic.parser.audio_file import AudioFile
+from tidysic.file.audio_file import AudioFile
 from tidysic.parser.tree import Tree
 
 

--- a/tidysic/organizer.py
+++ b/tidysic/organizer.py
@@ -1,7 +1,9 @@
 import shutil
 from pathlib import Path
+from tidysic.file.taggable import Taggable
 
 from tidysic.file.audio_file import AudioFile
+from tidysic.file.clutter_file import ClutterFile
 from tidysic.parser.tree import Tree
 
 
@@ -14,18 +16,29 @@ class Organizer:
         for audio_file in tree.audio_files:
             path = target / self._build_path(audio_file)
             path.mkdir(parents=True, exist_ok=True)
-            Organizer._copy_file(parent=path, audio_file=audio_file)
+            Organizer._copy_audio_file(parent=path, audio_file=audio_file)
+        
+        for clutter_file in tree.clutter_files:
+            path = target / self._build_path(clutter_file)
+            path.mkdir(parents=True, exist_ok=True)
+            Organizer._copy_clutter_file(parent=path, clutter_file=clutter_file)
 
         for child in tree.children:
             self.organize(child, target)
 
-    def _build_path(self, audio_file: AudioFile) -> Path:
+    def _build_path(self, taggable: Taggable) -> Path:
         path = Path()
         for attribute in self._attributes:
-            path = path / getattr(audio_file, attribute)
+            print(attribute)
+            path = path / getattr(taggable, attribute)
         return path
 
     @staticmethod
-    def _copy_file(parent: Path, audio_file: AudioFile) -> None:
+    def _copy_audio_file(parent: Path, audio_file: AudioFile) -> None:
         audio_path = parent / audio_file.get_title_with_extension()
         shutil.copyfile(audio_file.path, audio_path)
+    
+    @staticmethod
+    def _copy_clutter_file(parent: Path, clutter_file: ClutterFile) -> None:
+        clutter_path = parent / clutter_file.path.stem
+        shutil.copyfile(clutter_file.path, clutter_path)

--- a/tidysic/parser/tree.py
+++ b/tidysic/parser/tree.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
-from tidysic.parser.audio_file import AudioFile
+from tidysic.file.audio_file import AudioFile
+from tidysic.file.clutter_file import ClutterFile
+from tidysic.file.taggable import Taggable
 
 
 class Tree:
@@ -13,9 +15,10 @@ class Tree:
 
         self.children: set['Tree'] = set()
         self.audio_files: set[AudioFile] = set()
-        self.clutter_files: set[Path] = set()
+        self.clutter_files: set[ClutterFile] = set()
 
         self._parse()
+        self._parse_non_audio()
 
     def _parse(self) -> None:
         """
@@ -29,4 +32,50 @@ class Tree:
             elif AudioFile.is_audio_file(path):
                 self.audio_files.add(AudioFile(path))
             else:
-                self.clutter_files.add(path)
+                self.clutter_files.add(ClutterFile(path))
+
+    def _parse_non_audio(self) -> None:
+        """
+        Tags non-audio files with the tags common to all audio files in the same
+        directory and subdirectories.
+        """
+        _ = self._tag_clutter_and_return_common_tags()
+
+    def _tag_clutter_and_return_common_tags(self) -> Taggable:
+        """
+        Tags non-audio files with the tags common to all audio files in the same
+        directory and subdirectories, and returns the set of tags.
+        """
+        all_tagged = (
+            list(self.audio_files)
+            +
+            [
+                child._tag_clutter_and_return_common_tags()
+                for child in self.children
+            ]
+        )
+        common_tags = self._find_common_tags(all_tagged)
+        for clutter_file in self.clutter_files:
+            clutter_file.copy_tags_from(common_tags)
+        
+        return common_tags
+
+    @staticmethod
+    def _find_common_tags(
+        tagged_list: list[Taggable]
+    ) -> Taggable:
+        """
+        Finds the common tags shared by the given tagged objects.
+        """
+        common_tags = Taggable()
+        if tagged_list:
+            candidate = tagged_list.pop()
+            for key in common_tags.get_tags():
+                tag_value = getattr(candidate, key)
+                if all([
+                    getattr(tagged, key) == tag_value
+                    for tagged in tagged_list
+                ]):
+                    setattr(common_tags, key, tag_value)
+        return common_tags
+


### PR DESCRIPTION
Attempt at bringing `ClutterFile` tagging in the parsing process.

This is a counterproposal of #91 

How is it different?

- parsing does not take 50 lines of hackish inner functions
- Building the intersection of 2 tags is let to `Taggable` instead of bringing this logic inside the `Tree`

Otherwise, the `tidysic/files` and `Taggable` refactor are shamelessly taken from #91