### PR TITLE
Rename vscode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ venv
 __pycache__
 
 # VS
-.vscode
+.vscode/settings.json
 
 # MacOS
 .DS_Store

--- a/.vscode/settings.json.default
+++ b/.vscode/settings.json.default
@@ -1,0 +1,7 @@
+{
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": true
+    },
+    "python.formatting.provider": "black"
+} 


### PR DESCRIPTION
Rename `.vscode/settings.json` to `.vscode/settings.json.default`. This way, the actual settings file can stay `.gitignored`.