### PR TITLE
Advanced folder hierarchy

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -90,4 +90,4 @@ jobs:
         run: pip install mypy
 
       - name: Type checking
-        run: python -m mypy -p tidysic --ignore-missing-imports
+        run: python -m mypy -p tidysic --ignore-missing-imports --install-types --non-interactive

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,12 +1,4 @@
 [[package]]
-name = "appdirs"
-version = "1.4.4"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
@@ -16,38 +8,44 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "20.3.0"
+version = "21.2.0"
 description = "Classes Without Boilerplate"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
-docs = ["furo", "sphinx", "zope.interface"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
 
 [[package]]
 name = "black"
-version = "21.5b1"
+version = "21.9b0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
 python-versions = ">=3.6.2"
 
 [package.dependencies]
-appdirs = "*"
 click = ">=7.1.2"
 mypy-extensions = ">=0.4.3"
-pathspec = ">=0.8.1,<1"
+pathspec = ">=0.9.0,<1"
+platformdirs = ">=2"
 regex = ">=2020.1.8"
-toml = ">=0.10.1"
+tomli = ">=0.2.6,<2.0.0"
+typing-extensions = [
+    {version = ">=3.10.0.0", markers = "python_version < \"3.10\""},
+    {version = "!=3.10.0.1", markers = "python_version >= \"3.10\""},
+]
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.6.0)", "aiohttp-cors"]
+d = ["aiohttp (>=3.6.0)", "aiohttp-cors (>=0.4.0)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 python2 = ["typed-ast (>=1.4.2)"]
+uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "click"
@@ -70,7 +68,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "flake8"
-version = "3.9.1"
+version = "3.9.2"
 description = "the modular source code checker: pep8 pyflakes and co"
 category = "dev"
 optional = false
@@ -83,16 +81,17 @@ pyflakes = ">=2.3.0,<2.4.0"
 
 [[package]]
 name = "isort"
-version = "5.8.0"
+version = "5.9.3"
 description = "A Python utility / library to sort Python imports."
 category = "dev"
 optional = false
-python-versions = ">=3.6,<4.0"
+python-versions = ">=3.6.1,<4.0"
 
 [package.extras]
 pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
 requirements_deprecated_finder = ["pipreqs", "pip-api"]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
+plugins = ["setuptools"]
 
 [[package]]
 name = "mccabe"
@@ -104,7 +103,7 @@ python-versions = "*"
 
 [[package]]
 name = "more-itertools"
-version = "8.7.0"
+version = "8.10.0"
 description = "More routines for operating on iterables, beyond itertools"
 category = "dev"
 optional = false
@@ -144,22 +143,34 @@ python-versions = "*"
 
 [[package]]
 name = "packaging"
-version = "20.9"
+version = "21.0"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
 
 [[package]]
 name = "pathspec"
-version = "0.8.1"
+version = "0.9.0"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[[package]]
+name = "platformdirs"
+version = "2.3.0"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
+test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
 
 [[package]]
 name = "pluggy"
@@ -228,19 +239,19 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xm
 
 [[package]]
 name = "regex"
-version = "2021.4.4"
+version = "2021.8.28"
 description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
 python-versions = "*"
 
 [[package]]
-name = "toml"
-version = "0.10.2"
-description = "Python Library for Tom's Obvious, Minimal Language"
+name = "tomli"
+version = "1.2.1"
+description = "A lil' TOML parser"
 category = "dev"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "typed-ast"
@@ -252,7 +263,7 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "3.7.4.3"
+version = "3.10.0.2"
 description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "dev"
 optional = false
@@ -272,21 +283,17 @@ python-versions = "^3.9"
 content-hash = "0565288b22d241eac8cc41afd18d9adc64390c81e6c1016b12668d91fc252915"
 
 [metadata.files]
-appdirs = [
-    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
-    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
-]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
-    {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
+    {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
+    {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
 ]
 black = [
-    {file = "black-21.5b1-py3-none-any.whl", hash = "sha256:8a60071a0043876a4ae96e6c69bd3a127dad2c1ca7c8083573eb82f92705d008"},
-    {file = "black-21.5b1.tar.gz", hash = "sha256:23695358dbcb3deafe7f0a3ad89feee5999a46be5fec21f4f1d108be0bcdb3b1"},
+    {file = "black-21.9b0-py3-none-any.whl", hash = "sha256:380f1b5da05e5a1429225676655dddb96f5ae8c75bdf91e53d798871b902a115"},
+    {file = "black-21.9b0.tar.gz", hash = "sha256:7de4cfc7eb6b710de325712d40125689101d21d25283eed7e9998722cf10eb91"},
 ]
 click = [
     {file = "click-8.0.1-py3-none-any.whl", hash = "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"},
@@ -297,20 +304,20 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 flake8 = [
-    {file = "flake8-3.9.1-py2.py3-none-any.whl", hash = "sha256:3b9f848952dddccf635be78098ca75010f073bfe14d2c6bda867154bea728d2a"},
-    {file = "flake8-3.9.1.tar.gz", hash = "sha256:1aa8990be1e689d96c745c5682b687ea49f2e05a443aff1f8251092b0014e378"},
+    {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
+    {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
 ]
 isort = [
-    {file = "isort-5.8.0-py3-none-any.whl", hash = "sha256:2bb1680aad211e3c9944dbce1d4ba09a989f04e238296c87fe2139faa26d655d"},
-    {file = "isort-5.8.0.tar.gz", hash = "sha256:0a943902919f65c5684ac4e0154b1ad4fac6dcaa5d9f3426b732f1c8b5419be6"},
+    {file = "isort-5.9.3-py3-none-any.whl", hash = "sha256:e17d6e2b81095c9db0a03a8025a957f334d6ea30b26f9ec70805411e5c7c81f2"},
+    {file = "isort-5.9.3.tar.gz", hash = "sha256:9c2ea1e62d871267b78307fe511c0838ba0da28698c5732d54e2790bf3ba9899"},
 ]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 more-itertools = [
-    {file = "more-itertools-8.7.0.tar.gz", hash = "sha256:c5d6da9ca3ff65220c3bfd2a8db06d698f05d4d2b9be57e1deb2be5a45019713"},
-    {file = "more_itertools-8.7.0-py3-none-any.whl", hash = "sha256:5652a9ac72209ed7df8d9c15daf4e1aa0e3d2ccd3c87f8265a0673cd9cbc9ced"},
+    {file = "more-itertools-8.10.0.tar.gz", hash = "sha256:1debcabeb1df793814859d64a81ad7cb10504c24349368ccf214c664c474f41f"},
+    {file = "more_itertools-8.10.0-py3-none-any.whl", hash = "sha256:56ddac45541718ba332db05f464bebfb0768110111affd27f66e0051f276fa43"},
 ]
 mutagen = [
     {file = "mutagen-1.45.1-py3-none-any.whl", hash = "sha256:9c9f243fcec7f410f138cb12c21c84c64fde4195481a30c9bfb05b5f003adfed"},
@@ -345,12 +352,16 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 packaging = [
-    {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
-    {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
+    {file = "packaging-21.0-py3-none-any.whl", hash = "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"},
+    {file = "packaging-21.0.tar.gz", hash = "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7"},
 ]
 pathspec = [
-    {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
-    {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
+    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
+    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
+]
+platformdirs = [
+    {file = "platformdirs-2.3.0-py3-none-any.whl", hash = "sha256:8003ac87717ae2c7ee1ea5a84a1a61e87f3fbd16eb5aadba194ea30a9019f648"},
+    {file = "platformdirs-2.3.0.tar.gz", hash = "sha256:15b056538719b1c94bdaccb29e5f81879c7f7f0f4a153f46086d155dffcd4f0f"},
 ]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
@@ -377,51 +388,51 @@ pytest = [
     {file = "pytest-5.4.3.tar.gz", hash = "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"},
 ]
 regex = [
-    {file = "regex-2021.4.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:619d71c59a78b84d7f18891fe914446d07edd48dc8328c8e149cbe0929b4e000"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:47bf5bf60cf04d72bf6055ae5927a0bd9016096bf3d742fa50d9bf9f45aa0711"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:281d2fd05555079448537fe108d79eb031b403dac622621c78944c235f3fcf11"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:bd28bc2e3a772acbb07787c6308e00d9626ff89e3bfcdebe87fa5afbfdedf968"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:7c2a1af393fcc09e898beba5dd59196edaa3116191cc7257f9224beaed3e1aa0"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c38c71df845e2aabb7fb0b920d11a1b5ac8526005e533a8920aea97efb8ec6a4"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:96fcd1888ab4d03adfc9303a7b3c0bd78c5412b2bfbe76db5b56d9eae004907a"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:ade17eb5d643b7fead300a1641e9f45401c98eee23763e9ed66a43f92f20b4a7"},
-    {file = "regex-2021.4.4-cp36-cp36m-win32.whl", hash = "sha256:e8e5b509d5c2ff12f8418006d5a90e9436766133b564db0abaec92fd27fcee29"},
-    {file = "regex-2021.4.4-cp36-cp36m-win_amd64.whl", hash = "sha256:11d773d75fa650cd36f68d7ca936e3c7afaae41b863b8c387a22aaa78d3c5c79"},
-    {file = "regex-2021.4.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d3029c340cfbb3ac0a71798100ccc13b97dddf373a4ae56b6a72cf70dfd53bc8"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:18c071c3eb09c30a264879f0d310d37fe5d3a3111662438889ae2eb6fc570c31"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:4c557a7b470908b1712fe27fb1ef20772b78079808c87d20a90d051660b1d69a"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:01afaf2ec48e196ba91b37451aa353cb7eda77efe518e481707e0515025f0cd5"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:3a9cd17e6e5c7eb328517969e0cb0c3d31fd329298dd0c04af99ebf42e904f82"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:90f11ff637fe8798933fb29f5ae1148c978cccb0452005bf4c69e13db951e765"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:919859aa909429fb5aa9cf8807f6045592c85ef56fdd30a9a3747e513db2536e"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:339456e7d8c06dd36a22e451d58ef72cef293112b559010db3d054d5560ef439"},
-    {file = "regex-2021.4.4-cp37-cp37m-win32.whl", hash = "sha256:67bdb9702427ceddc6ef3dc382455e90f785af4c13d495f9626861763ee13f9d"},
-    {file = "regex-2021.4.4-cp37-cp37m-win_amd64.whl", hash = "sha256:32e65442138b7b76dd8173ffa2cf67356b7bc1768851dded39a7a13bf9223da3"},
-    {file = "regex-2021.4.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1e1c20e29358165242928c2de1482fb2cf4ea54a6a6dea2bd7a0e0d8ee321500"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:314d66636c494ed9c148a42731b3834496cc9a2c4251b1661e40936814542b14"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6d1b01031dedf2503631d0903cb563743f397ccaf6607a5e3b19a3d76fc10480"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:741a9647fcf2e45f3a1cf0e24f5e17febf3efe8d4ba1281dcc3aa0459ef424dc"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:4c46e22a0933dd783467cf32b3516299fb98cfebd895817d685130cc50cd1093"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:e512d8ef5ad7b898cdb2d8ee1cb09a8339e4f8be706d27eaa180c2f177248a10"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:980d7be47c84979d9136328d882f67ec5e50008681d94ecc8afa8a65ed1f4a6f"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:ce15b6d103daff8e9fee13cf7f0add05245a05d866e73926c358e871221eae87"},
-    {file = "regex-2021.4.4-cp38-cp38-win32.whl", hash = "sha256:a91aa8619b23b79bcbeb37abe286f2f408d2f2d6f29a17237afda55bb54e7aac"},
-    {file = "regex-2021.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:c0502c0fadef0d23b128605d69b58edb2c681c25d44574fc673b0e52dce71ee2"},
-    {file = "regex-2021.4.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:598585c9f0af8374c28edd609eb291b5726d7cbce16be6a8b95aa074d252ee17"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:ee54ff27bf0afaf4c3b3a62bcd016c12c3fdb4ec4f413391a90bd38bc3624605"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7d9884d86dd4dd489e981d94a65cd30d6f07203d90e98f6f657f05170f6324c9"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:bf5824bfac591ddb2c1f0a5f4ab72da28994548c708d2191e3b87dd207eb3ad7"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:563085e55b0d4fb8f746f6a335893bda5c2cef43b2f0258fe1020ab1dd874df8"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b9c3db21af35e3b3c05764461b262d6f05bbca08a71a7849fd79d47ba7bc33ed"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:3916d08be28a1149fb97f7728fca1f7c15d309a9f9682d89d79db75d5e52091c"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:fd45ff9293d9274c5008a2054ecef86a9bfe819a67c7be1afb65e69b405b3042"},
-    {file = "regex-2021.4.4-cp39-cp39-win32.whl", hash = "sha256:fa4537fb4a98fe8fde99626e4681cc644bdcf2a795038533f9f711513a862ae6"},
-    {file = "regex-2021.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:97f29f57d5b84e73fbaf99ab3e26134e6687348e95ef6b48cfd2c06807005a07"},
-    {file = "regex-2021.4.4.tar.gz", hash = "sha256:52ba3d3f9b942c49d7e4bc105bb28551c44065f139a65062ab7912bef10c9afb"},
+    {file = "regex-2021.8.28-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9d05ad5367c90814099000442b2125535e9d77581855b9bee8780f1b41f2b1a2"},
+    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3bf1bc02bc421047bfec3343729c4bbbea42605bcfd6d6bfe2c07ade8b12d2a"},
+    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f6a808044faae658f546dd5f525e921de9fa409de7a5570865467f03a626fc0"},
+    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a617593aeacc7a691cc4af4a4410031654f2909053bd8c8e7db837f179a630eb"},
+    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:79aef6b5cd41feff359acaf98e040844613ff5298d0d19c455b3d9ae0bc8c35a"},
+    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0fc1f8f06977c2d4f5e3d3f0d4a08089be783973fc6b6e278bde01f0544ff308"},
+    {file = "regex-2021.8.28-cp310-cp310-win32.whl", hash = "sha256:6eebf512aa90751d5ef6a7c2ac9d60113f32e86e5687326a50d7686e309f66ed"},
+    {file = "regex-2021.8.28-cp310-cp310-win_amd64.whl", hash = "sha256:ac88856a8cbccfc14f1b2d0b829af354cc1743cb375e7f04251ae73b2af6adf8"},
+    {file = "regex-2021.8.28-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c206587c83e795d417ed3adc8453a791f6d36b67c81416676cad053b4104152c"},
+    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8690ed94481f219a7a967c118abaf71ccc440f69acd583cab721b90eeedb77c"},
+    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:328a1fad67445550b982caa2a2a850da5989fd6595e858f02d04636e7f8b0b13"},
+    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c7cb4c512d2d3b0870e00fbbac2f291d4b4bf2634d59a31176a87afe2777c6f0"},
+    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66256b6391c057305e5ae9209941ef63c33a476b73772ca967d4a2df70520ec1"},
+    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8e44769068d33e0ea6ccdf4b84d80c5afffe5207aa4d1881a629cf0ef3ec398f"},
+    {file = "regex-2021.8.28-cp36-cp36m-win32.whl", hash = "sha256:08d74bfaa4c7731b8dac0a992c63673a2782758f7cfad34cf9c1b9184f911354"},
+    {file = "regex-2021.8.28-cp36-cp36m-win_amd64.whl", hash = "sha256:abb48494d88e8a82601af905143e0de838c776c1241d92021e9256d5515b3645"},
+    {file = "regex-2021.8.28-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b4c220a1fe0d2c622493b0a1fd48f8f991998fb447d3cd368033a4b86cf1127a"},
+    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4a332404baa6665b54e5d283b4262f41f2103c255897084ec8f5487ce7b9e8e"},
+    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c61dcc1cf9fd165127a2853e2c31eb4fb961a4f26b394ac9fe5669c7a6592892"},
+    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ee329d0387b5b41a5dddbb6243a21cb7896587a651bebb957e2d2bb8b63c0791"},
+    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f60667673ff9c249709160529ab39667d1ae9fd38634e006bec95611f632e759"},
+    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b844fb09bd9936ed158ff9df0ab601e2045b316b17aa8b931857365ea8586906"},
+    {file = "regex-2021.8.28-cp37-cp37m-win32.whl", hash = "sha256:4cde065ab33bcaab774d84096fae266d9301d1a2f5519d7bd58fc55274afbf7a"},
+    {file = "regex-2021.8.28-cp37-cp37m-win_amd64.whl", hash = "sha256:1413b5022ed6ac0d504ba425ef02549a57d0f4276de58e3ab7e82437892704fc"},
+    {file = "regex-2021.8.28-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ed4b50355b066796dacdd1cf538f2ce57275d001838f9b132fab80b75e8c84dd"},
+    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28fc475f560d8f67cc8767b94db4c9440210f6958495aeae70fac8faec631797"},
+    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdc178caebd0f338d57ae445ef8e9b737ddf8fbc3ea187603f65aec5b041248f"},
+    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:999ad08220467b6ad4bd3dd34e65329dd5d0df9b31e47106105e407954965256"},
+    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:808ee5834e06f57978da3e003ad9d6292de69d2bf6263662a1a8ae30788e080b"},
+    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d5111d4c843d80202e62b4fdbb4920db1dcee4f9366d6b03294f45ed7b18b42e"},
+    {file = "regex-2021.8.28-cp38-cp38-win32.whl", hash = "sha256:473858730ef6d6ff7f7d5f19452184cd0caa062a20047f6d6f3e135a4648865d"},
+    {file = "regex-2021.8.28-cp38-cp38-win_amd64.whl", hash = "sha256:31a99a4796bf5aefc8351e98507b09e1b09115574f7c9dbb9cf2111f7220d2e2"},
+    {file = "regex-2021.8.28-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:04f6b9749e335bb0d2f68c707f23bb1773c3fb6ecd10edf0f04df12a8920d468"},
+    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b006628fe43aa69259ec04ca258d88ed19b64791693df59c422b607b6ece8bb"},
+    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:121f4b3185feaade3f85f70294aef3f777199e9b5c0c0245c774ae884b110a2d"},
+    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a577a21de2ef8059b58f79ff76a4da81c45a75fe0bfb09bc8b7bb4293fa18983"},
+    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1743345e30917e8c574f273f51679c294effba6ad372db1967852f12c76759d8"},
+    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e1e8406b895aba6caa63d9fd1b6b1700d7e4825f78ccb1e5260551d168db38ed"},
+    {file = "regex-2021.8.28-cp39-cp39-win32.whl", hash = "sha256:ed283ab3a01d8b53de3a05bfdf4473ae24e43caee7dcb5584e86f3f3e5ab4374"},
+    {file = "regex-2021.8.28-cp39-cp39-win_amd64.whl", hash = "sha256:610b690b406653c84b7cb6091facb3033500ee81089867ee7d59e675f9ca2b73"},
+    {file = "regex-2021.8.28.tar.gz", hash = "sha256:f585cbbeecb35f35609edccb95efd95a3e35824cd7752b586503f7e6087303f1"},
 ]
-toml = [
-    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
-    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+tomli = [
+    {file = "tomli-1.2.1-py3-none-any.whl", hash = "sha256:8dd0e9524d6f386271a36b41dbf6c57d8e32fd96fd22b6584679dc569d20899f"},
+    {file = "tomli-1.2.1.tar.gz", hash = "sha256:a5b75cb6f3968abb47af1b40c1819dc519ea82bcc065776a866e8d74c5ca9442"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
@@ -456,9 +467,9 @@ typed-ast = [
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
-    {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
-    {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
+    {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},
+    {file = "typing_extensions-3.10.0.2-py3-none-any.whl", hash = "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"},
+    {file = "typing_extensions-3.10.0.2.tar.gz", hash = "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/tests/test_formatted_string.py
+++ b/tests/test_formatted_string.py
@@ -1,0 +1,56 @@
+import pytest
+from tidysic.file.taggable import Taggable
+from tidysic.settings.formatted_string import FormattedString
+
+
+def test_validation():
+    with pytest.raises(ValueError):
+        too_many_brackets = "{{{artist}}"
+        FormattedString(too_many_brackets)
+
+    with pytest.raises(ValueError):
+        too_few_brackets = "{artist}}"
+        FormattedString(too_few_brackets)
+
+    with pytest.raises(ValueError):
+        mismatched_brackets = "{{artist}"
+        FormattedString(mismatched_brackets)
+
+    with pytest.raises(ValueError):
+        invalid_tag = "{{invalid_tag}}"
+        FormattedString(invalid_tag)
+
+
+def test_extra_text():
+    fs = FormattedString(
+        "{surrounding stuff {artist} here too }always present {{album}}"
+    )
+
+    tagged_whole = Taggable(album="Album", artist="Artist")
+    assert (
+        fs.write(tagged_whole)
+        == "surrounding stuff Artist here too always present Album"
+    )
+
+    tagged_only_album = Taggable(album="Album")
+    assert fs.write(tagged_only_album) == "always present Album"
+
+    tagged_empty = Taggable()
+    assert fs.write(tagged_empty) == "always present "
+
+
+def test_empty_string():
+    fs = FormattedString("{{artist}}")
+    tagged = Taggable()
+
+    with pytest.raises(RuntimeError):
+        fs.write(tagged)
+
+    fs = FormattedString("{*{artist}}")
+    assert fs.write(tagged) == "Unknown artist"
+
+
+def test_number_formatting():
+    fs = FormattedString("{{tracknumber:03d}}")
+    tagged = Taggable(tracknumber="34")
+    assert fs.write(tagged) == "034"

--- a/tests/test_structure_parser.py
+++ b/tests/test_structure_parser.py
@@ -1,0 +1,34 @@
+import pytest
+from tidysic.settings.parser import parse_settings
+
+settings_ok = """\
+artist {{artist}}
+{{tracknumber:02d}. }{{title}}
+"""
+
+settings_invalid_tag = """\
+invalid_tag {{artist}}
+{{title}}
+"""
+
+settings_invalid_format = """\
+artist {{artist}}
+{title}
+"""
+
+settings_tag_in_step = """\
+artist {{artist}}
+{{album}}
+{{title}}
+"""
+
+
+def test_parser():
+    parse_settings(settings_ok)
+
+    with pytest.raises(ValueError):
+        parse_settings(settings_invalid_tag)
+    with pytest.raises(ValueError):
+        parse_settings(settings_invalid_format)
+    with pytest.raises(ValueError):
+        parse_settings(settings_tag_in_step)

--- a/tidysic/file/audio_file.py
+++ b/tidysic/file/audio_file.py
@@ -31,10 +31,6 @@ class AudioFile(TaggedFile):
         except ID3NoHeaderError:
             return dict()
 
-    def get_title_with_extension(self) -> str:
-        title = self.title if self.title is not None else "Unknown track"
-        return title + self.extension
-
     @staticmethod
     def is_audio_file(path: Path) -> bool:
         return path.is_file() and path.suffix in AudioFile.extensions

--- a/tidysic/file/taggable.py
+++ b/tidysic/file/taggable.py
@@ -39,3 +39,11 @@ class Taggable:
     @staticmethod
     def get_tag_names() -> tuple[str, ...]:
         return tuple(field.name for field in fields(Taggable))
+
+    @staticmethod
+    def get_numeric_tag_names() -> tuple[str, ...]:
+        return ("date", "tracknumber")
+
+    @staticmethod
+    def get_non_numeric_tag_names() -> tuple[str, ...]:
+        return ("album", "artist", "title", "genre")

--- a/tidysic/main.py
+++ b/tidysic/main.py
@@ -1,18 +1,39 @@
 import click
 import pkg_resources
 
+from tidysic.settings.parser import default_config
 from tidysic.tidysic import Tidysic
 
 
+def dump_config(ctx, param, value):
+    if not value or ctx.resilient_parsing:
+        return
+    click.echo(default_config)
+    ctx.exit()
+
+
 @click.command()
-@click.version_option(version=pkg_resources.require("tidysic")[0].version)
 @click.option(
     "-v", "--verbose", is_flag=True, help="Show more information when running."
 )
+@click.version_option(version=pkg_resources.require("tidysic")[0].version)
+@click.option(
+    "--dump-config",
+    is_flag=True,
+    callback=dump_config,
+    expose_value=False,
+    is_eager=True,
+    help="Dump the default config and exit.",
+)
+@click.option(
+    "--config",
+    "config_path",
+    type=click.Path(exists=True, file_okay=True),
+    help="Optional, path to a .tidysic config file.",
+)
 @click.argument("source", type=click.Path(exists=True, file_okay=False))
 @click.argument("target", type=click.Path(exists=False, file_okay=False))
-@click.option("--config", "config_path", type=click.Path(exists=True, file_okay=True))
-def run(verbose: bool, source: str, target: str, config_path: str) -> None:
+def run(verbose: bool, config_path: str, source: str, target: str) -> None:
     tidysic = Tidysic(source, target, config_path)
     tidysic.run()
 

--- a/tidysic/main.py
+++ b/tidysic/main.py
@@ -11,9 +11,9 @@ from tidysic.tidysic import Tidysic
 )
 @click.argument("source", type=click.Path(exists=True, file_okay=False))
 @click.argument("target", type=click.Path(exists=False, file_okay=False))
-@click.argument("pattern", type=str)
-def run(verbose: bool, source: str, target: str, pattern: str) -> None:
-    tidysic = Tidysic(source, target, pattern)
+@click.option("--config", "config_path", type=click.Path(exists=True, file_okay=True))
+def run(verbose: bool, source: str, target: str, config_path: str) -> None:
+    tidysic = Tidysic(source, target, config_path)
     tidysic.run()
 
 

--- a/tidysic/organizer.py
+++ b/tidysic/organizer.py
@@ -25,6 +25,8 @@ class Organizer:
         for clutter_file in tree.clutter_files:
             path = target / self._build_path(clutter_file)
             path.mkdir(parents=True, exist_ok=True)
+
+            path /= clutter_file.path.name
             shutil.copyfile(clutter_file.path, path)
 
         for child in tree.children:

--- a/tidysic/settings/formatted_string.py
+++ b/tidysic/settings/formatted_string.py
@@ -14,31 +14,29 @@ class FormattedString:
 
     def write(self, taggable: Taggable):
         """
-        Produces the string built using the tags found in the given taggable
+        Produces the string built using the tags found in the given taggable.
         """
         pattern = r"\{(.*?\{(\w+)(:.+?)?\}.*?)\}"
         matches = re.findall(pattern, self.raw_string)
 
         return_string = self.raw_string
 
-        substitutions = []
         for to_substitute, tag_name, format_spec in matches:
 
             value = getattr(taggable, tag_name, None)
-            if tag_name in Taggable.get_numeric_tag_names() and value:
+            if value and tag_name in Taggable.get_numeric_tag_names():
                 value = int(value)
-            if tag_name in Taggable.get_non_numeric_tag_names() and not value:
+            if not value and tag_name in Taggable.get_non_numeric_tag_names():
                 value = f"Unknown {tag_name}"
 
             formattable = to_substitute.replace(
-                f"{{{tag_name}{format_spec}}}", f"{{{format_spec}}}"
+                "{%s%s}" % (tag_name, format_spec), "{%s}" % format_spec
             )
-            substitutions.append(
-                (f"{{{to_substitute}}}", formattable.format(value) if value else "")
+            return_string = return_string.replace(
+                "{%s}" % to_substitute,
+                formattable.format(value) if value else "",
+                1,
             )
-
-        for old, new in substitutions:
-            return_string = return_string.replace(old, new)
 
         return return_string
 

--- a/tidysic/settings/formatted_string.py
+++ b/tidysic/settings/formatted_string.py
@@ -62,6 +62,7 @@ class FormattedString:
                     raise ValueError(f"too many closing brackets (col {i})")
 
                 if bracket_depth == 0:
+                    current_tag_name = current_tag_name.split(":")[0]
                     if current_tag_name not in Taggable.get_tag_names():
                         raise ValueError(f"unknown tag name '{current_tag_name}'")
                     current_tag_name = ""

--- a/tidysic/settings/formatted_string.py
+++ b/tidysic/settings/formatted_string.py
@@ -1,0 +1,70 @@
+import re
+
+from tidysic.file.taggable import Taggable
+
+
+class FormattedString:
+    def __init__(self, raw_string: str):
+        try:
+            self.validate(raw_string)
+        except ValueError as e:
+            raise ValueError(f"Could not create formatted string, {e}")
+
+        self.raw_string = raw_string
+
+    def write(self, taggable: Taggable):
+        """
+        Produces the string built using the tags found in the given taggable
+        """
+        pattern = r"\{(.*?\{(\w+)(:.+?)?\}.*?)\}"
+        matches = re.findall(pattern, self.raw_string)
+
+        return_string = self.raw_string
+
+        substitutions = []
+        for to_substitute, tag_name, format_spec in matches:
+
+            value = getattr(taggable, tag_name, None)
+            if tag_name in Taggable.get_numeric_tag_names() and value:
+                value = int(value)
+            if tag_name in Taggable.get_non_numeric_tag_names() and not value:
+                value = f"Unknown {tag_name}"
+
+            formattable = to_substitute.replace(
+                f"{{{tag_name}{format_spec}}}", f"{{{format_spec}}}"
+            )
+            substitutions.append(
+                (f"{{{to_substitute}}}", formattable.format(value) if value else "")
+            )
+
+        for old, new in substitutions:
+            return_string = return_string.replace(old, new)
+
+        return return_string
+
+    @staticmethod
+    def validate(raw_string: str):
+        """
+        Raises a ValueError if the given string is badly formatted.
+        """
+        bracket_depth = 0
+        current_tag_name = ""
+
+        for i, char in enumerate(raw_string):
+            if char == "{":
+                bracket_depth += 1
+                if bracket_depth > 2:
+                    raise ValueError(f"too many opening brackets (col {i})")
+
+            elif char == "}":
+                bracket_depth -= 1
+                if bracket_depth < 0:
+                    raise ValueError(f"too many closing brackets (col {i})")
+
+                if bracket_depth == 0:
+                    if current_tag_name not in Taggable.get_tag_names():
+                        raise ValueError(f"unknown tag name '{current_tag_name}'")
+                    current_tag_name = ""
+
+            elif bracket_depth == 2:
+                current_tag_name += char

--- a/tidysic/settings/parser.py
+++ b/tidysic/settings/parser.py
@@ -3,20 +3,65 @@ from tidysic.settings.structure import Structure, StructureStep
 
 
 def parse_settings(settings_file: str) -> Structure:
-    structure: Structure = []
 
     with open(settings_file, "r") as file:
+        structure_lines = [line.strip() for line in file]
+        structure_lines = [
+            line for line in structure_lines if line != "" and line[0] != "#"
+        ]
         try:
-            for i, line in enumerate(file):
-                line = line.strip()
-                if line[0] == "#":
-                    continue
-
+            folders: list[StructureStep] = []
+            for line in structure_lines[:-1]:
                 [tag, raw_format] = line.split(" ", maxsplit=1)
                 formatted_string = FormattedString(raw_format)
-                structure.append(StructureStep(tag, formatted_string))
+                folders.append(StructureStep(tag, formatted_string))
+
+            track_line = structure_lines[-1]
+            track_format = FormattedString(track_line)
+
+            return Structure(folders=folders, track_format=track_format)
 
         except ValueError as error:
             raise ValueError(f"Could not parse settings file: {error}")
 
-    return structure
+
+default_config = """\
+# This is the default configuration file for your tidy music folder.
+# You will define here how the music will be sorted into a hierarchy of folders.
+
+# Each line describes a step in the hierarchy, it must be formatted as follow:
+
+# The first word is the tag by which to sort the files, it must be one of the
+# following:
+#
+#     album, artist, title, genre, tracknumber, date
+
+# The rest of the line describes how to format the folder's name. Here is how it works:
+#
+# The value of any tag can be inserted using double curly brackets like this:
+#     {{album}}
+#
+# If the tag value is not set, this will be replaced by a blank.
+#
+# You can use the space between the sets of brackets to add text that will only
+# be displayed if the value is set, for instance,
+#     {{tracknumber}. }{{title}}
+# will turn into, for instance,
+#     1. Intro
+# or
+#     Intro
+# depending on whether the track number is set.
+#
+# You can use formatting options as in python, for instance you can pad the
+# track number like so:
+#     {{tracknumber:02d}. }{{title}}
+# to get
+#     01. Intro
+
+# After the lines describing the folders, you must describe the formatting of
+# the tracks themselves, using the same rules as before.
+
+artist {{artist}}
+album {({date}) }{{album}}
+{{tracknumber:02d}. }{{title}}
+"""

--- a/tidysic/settings/parser.py
+++ b/tidysic/settings/parser.py
@@ -61,6 +61,14 @@ default_config = """\
 #     Intro
 # depending on whether the track number is set.
 #
+# By adding * right after the first bracket, it will behave differently if the
+# tag value hasn't been set. Instead of producing a blank string, it will turn
+# into "blank <tag name>". For instance,
+#     {{album}}
+# will turn into
+#     Unknown album
+# if the album tag isn't set.
+#
 # You can use formatting options as in python, for instance you can pad the
 # track number like so:
 #     {{tracknumber:02d}. }{{title}}

--- a/tidysic/settings/parser.py
+++ b/tidysic/settings/parser.py
@@ -1,0 +1,22 @@
+from tidysic.settings.formatted_string import FormattedString
+from tidysic.settings.structure import Structure, StructureStep
+
+
+def parse_settings(settings_file: str) -> Structure:
+    structure: Structure = []
+
+    with open(settings_file, "r") as file:
+        try:
+            for i, line in enumerate(file):
+                line = line.strip()
+                if line[0] == "#":
+                    continue
+
+                [tag, raw_format] = line.split(" ", maxsplit=1)
+                formatted_string = FormattedString(raw_format)
+                structure.append(StructureStep(tag, formatted_string))
+
+        except ValueError as error:
+            raise ValueError(f"Could not parse settings file: {error}")
+
+    return structure

--- a/tidysic/settings/structure.py
+++ b/tidysic/settings/structure.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+
+from tidysic.file.taggable import Taggable
+from tidysic.settings.formatted_string import FormattedString
+
+
+@dataclass
+class StructureStep:
+    tag: str
+    formatted_string: FormattedString
+
+    def __init__(self, tag: str, formatted_string: FormattedString):
+        if tag not in Taggable.get_tag_names():
+            raise ValueError(f"unknown tag name '{tag}'")
+
+        self.tag = tag
+        self.formatted_string = formatted_string
+
+
+@dataclass
+class Structure:
+    folders: list[StructureStep]
+    track_format: FormattedString
+
+
+default_structure = Structure(
+    folders=[
+        StructureStep("artist", FormattedString("{{artist}}")),
+        StructureStep("album", FormattedString("{({date}) }{{album}}")),
+    ],
+    track_format=FormattedString("{{tracknumber}. }{{title}}"),
+)

--- a/tidysic/tidysic.py
+++ b/tidysic/tidysic.py
@@ -7,17 +7,18 @@ from tidysic.settings.structure import default_structure
 
 
 class Tidysic:
-    def __init__(self, source: str, target: str, settings_file: str) -> None:
+    def __init__(self, source: str, target: str, settings_path: str) -> None:
         self._tree = Tree(Path(source))
         self._target = Path(target)
 
         structure = default_structure
-        if settings_file:
-            structure = parse_settings(settings_file)
+        if settings_path:
+            with open(settings_path, "r") as settings:
+                structure = parse_settings(settings.read())
         else:
             folder_settings_file = self._target / ".tidysic"
             if folder_settings_file.exists():
-                structure = parse_settings(str(folder_settings_file))
+                structure = parse_settings(folder_settings_file.read_text())
         self._organizer = Organizer(structure)
 
     def run(self) -> None:

--- a/tidysic/tidysic.py
+++ b/tidysic/tidysic.py
@@ -2,13 +2,23 @@ from pathlib import Path
 
 from tidysic.organizer import Organizer
 from tidysic.parser.tree import Tree
+from tidysic.settings.parser import parse_settings
+from tidysic.settings.structure import default_structure
 
 
 class Tidysic:
-    def __init__(self, source: str, target: str, pattern: str) -> None:
+    def __init__(self, source: str, target: str, settings_file: str) -> None:
         self._tree = Tree(Path(source))
         self._target = Path(target)
-        self._organizer = Organizer(pattern)
+
+        structure = default_structure
+        if settings_file:
+            structure = parse_settings(settings_file)
+        else:
+            folder_settings_file = self._target / ".tidysic"
+            if folder_settings_file.exists():
+                structure = parse_settings(str(folder_settings_file))
+        self._organizer = Organizer(structure)
 
     def run(self) -> None:
         self._organizer.organize(self._tree, self._target)


### PR DESCRIPTION
Close #94 

This PR restores the formatted strings from the main branch.

Also fixes a small issue that prevented copying clutter files.

# Config file

The folder structure is now defined in a `.tidysic` config file. These settings are read, in order of priority, from

- an explicit argument `--config path/to/config/file` if given
- the target folder's `.tidysic` file if it exists
- the defaults otherwise

# Changes to the CLI

A new option has been added to the CLI.

`tidysic --dump-config` will dump a default config in `stdout`. This default config comes with an explanation of the format to use. It is intended to be used as such : `tidysic --dump-config > ~/Music/.tidysic`.