### PR TITLE
Handle rich tracknumbers.

### DIFF
--- a/tests/test_formatted_string.py
+++ b/tests/test_formatted_string.py
@@ -54,3 +54,9 @@ def test_number_formatting():
     fs = FormattedString("{{tracknumber:03d}}")
     tagged = Taggable(tracknumber="34")
     assert fs.write(tagged) == "034"
+
+
+def test_rich_tracknumber():
+    fs = FormattedString("{{tracknumber:02d}}")
+    tagged = Taggable(tracknumber="03/12")
+    assert fs.write(tagged) == "03"

--- a/tidysic/settings/formatted_string.py
+++ b/tidysic/settings/formatted_string.py
@@ -27,6 +27,10 @@ class FormattedString:
 
             value = getattr(taggable, tag_name, None)
             if value and tag_name in Taggable.get_numeric_tag_names():
+                if tag_name == "tracknumber":
+                    match = re.match(r"(\d+)/\d+", value)
+                    if match is not None:
+                        value = match.group(1)
                 value = int(value)
 
             if not value and required:


### PR DESCRIPTION
Close #105 

From all the files which I have parsed. I only found two types of track numbers: `\d{2}` and `\d{2}/\d{2}`. Consequently, I simply implemented extraction of the first integer in the second case to make it int-castable.